### PR TITLE
Add Just Cancel — subscription cancellation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [Tiller Money](https://www.tillerhq.com/) - A service that imports financial transactions into Google Sheets.
 - [Tricount](https://www.tricount.com/) - A mobile app that helps group of people share expenses.
 - [YNAB](https://www.youneedabudget.com/) - A multi-platform personal budgeting program based on the envelope method.
+- [Just Cancel](https://www.justcancel.io/) - Upload a bank statement, AI finds all recurring subscriptions, and gives you direct cancel links for 450+ services.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 - [Tiller Money](https://www.tillerhq.com/) - A service that imports financial transactions into Google Sheets.
 - [Tricount](https://www.tricount.com/) - A mobile app that helps group of people share expenses.
 - [YNAB](https://www.youneedabudget.com/) - A multi-platform personal budgeting program based on the envelope method.
+- [JustCancel](https://www.justcancel.io) - Upload your bank statement to find forgotten subscriptions and get cancel links for 1,100+ services. $5 one-time, no bank connection.
 - [Just Cancel](https://www.justcancel.io/) - Upload a bank statement, AI finds all recurring subscriptions, and gives you direct cancel links for 450+ services.
 
 ## License


### PR DESCRIPTION
Added [Just Cancel](https://www.justcancel.io) to the Tools section. It analyzes bank statements with AI to find all recurring subscriptions and provides direct cancel links for 450+ services.