### PR TITLE
Add IndepAI to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 ### Tools
 
 - [Ghostfolio](https://github.com/ghostfolio/ghostfolio/) - A web-based open source wealth management software.
+- [IndepAI](https://indepai.app) - A financial independence (FIRE) calculator for digital nomads and expats, with geo-arbitrage data across 11,800+ cities and free Coast/Barista/Lean FIRE calculators.
 - [Mint](https://www.mint.com/) - A web-based personal financial management service for US and Canada.
 - [Tiller Money](https://www.tillerhq.com/) - A service that imports financial transactions into Google Sheets.
 - [Tricount](https://www.tricount.com/) - A mobile app that helps group of people share expenses.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 ### Tools
 
 - [Ghostfolio](https://github.com/ghostfolio/ghostfolio/) - A web-based open source wealth management software.
-- [IndepAI](https://indepai.app) - A financial independence (FIRE) calculator for digital nomads and expats, with geo-arbitrage data across 11,800+ cities and free Coast/Barista/Lean FIRE calculators.
+- [IndepAI](https://indepai.app/tools/coast-fire-calculator) - A free Coast FIRE calculator for digital nomads and expats, backed by real cost of living data across 11,400+ cities instead of a single generic estimate.
 - [Mint](https://www.mint.com/) - A web-based personal financial management service for US and Canada.
 - [Tiller Money](https://www.tillerhq.com/) - A service that imports financial transactions into Google Sheets.
 - [Tricount](https://www.tricount.com/) - A mobile app that helps group of people share expenses.


### PR DESCRIPTION
Adds IndepAI, a free Coast FIRE calculator for digital nomads and expats, to the Tools section in alphabetical order between Ghostfolio and Mint.

It's backed by real cost of living data across 11,400 plus cities instead of a single generic estimate, so the coasting number reflects where you'd actually live. Free, no signup required. Disclosure: I'm the founder.